### PR TITLE
change: 内部调用和访问属性使用 this 而不是变量名

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,7 +1,7 @@
 /**
 * @1900-2100区间内的公历、农历互转
 * @charset UTF-8
-* @Author  Jea杨(JJonline@JJonline.Cn) 
+* @Author  Jea杨(JJonline@JJonline.Cn)
 * @Time    2014-7-21
 * @Time    2016-8-13 Fixed 2033hex、Attribution Annals
 * @Time    2016-9-25 Fixed lunar LeapMonth Param Bug
@@ -15,7 +15,7 @@ var calendar = {
     /**
       * 农历1900-2100的润大小信息表
       * @Array Of Property
-      * @return Hex 
+      * @return Hex
       */
     lunarInfo:[0x04bd8,0x04ae0,0x0a570,0x054d5,0x0d260,0x0d950,0x16554,0x056a0,0x09ad0,0x055d2,//1900-1909
             0x04ae0,0x0a5b6,0x0a4d0,0x0d250,0x1d255,0x0b540,0x0d6a0,0x0ada2,0x095b0,0x14977,//1910-1919
@@ -43,44 +43,44 @@ var calendar = {
     /**
       * 公历每个月份的天数普通表
       * @Array Of Property
-      * @return Number 
+      * @return Number
       */
     solarMonth:[31,28,31,30,31,30,31,31,30,31,30,31],
 
     /**
       * 天干地支之天干速查表
       * @Array Of Property trans["甲","乙","丙","丁","戊","己","庚","辛","壬","癸"]
-      * @return Cn string 
+      * @return Cn string
       */
     Gan:["\u7532","\u4e59","\u4e19","\u4e01","\u620a","\u5df1","\u5e9a","\u8f9b","\u58ec","\u7678"],
 
     /**
       * 天干地支之地支速查表
-      * @Array Of Property 
+      * @Array Of Property
       * @trans["子","丑","寅","卯","辰","巳","午","未","申","酉","戌","亥"]
-      * @return Cn string 
+      * @return Cn string
       */
     Zhi:["\u5b50","\u4e11","\u5bc5","\u536f","\u8fb0","\u5df3","\u5348","\u672a","\u7533","\u9149","\u620c","\u4ea5"],
 
     /**
       * 天干地支之地支速查表<=>生肖
-      * @Array Of Property 
+      * @Array Of Property
       * @trans["鼠","牛","虎","兔","龙","蛇","马","羊","猴","鸡","狗","猪"]
-      * @return Cn string 
+      * @return Cn string
       */
     Animals:["\u9f20","\u725b","\u864e","\u5154","\u9f99","\u86c7","\u9a6c","\u7f8a","\u7334","\u9e21","\u72d7","\u732a"],
 
     /**
       * 24节气速查表
-      * @Array Of Property 
+      * @Array Of Property
       * @trans["小寒","大寒","立春","雨水","惊蛰","春分","清明","谷雨","立夏","小满","芒种","夏至","小暑","大暑","立秋","处暑","白露","秋分","寒露","霜降","立冬","小雪","大雪","冬至"]
-      * @return Cn string 
+      * @return Cn string
       */
     solarTerm:["\u5c0f\u5bd2","\u5927\u5bd2","\u7acb\u6625","\u96e8\u6c34","\u60ca\u86f0","\u6625\u5206","\u6e05\u660e","\u8c37\u96e8","\u7acb\u590f","\u5c0f\u6ee1","\u8292\u79cd","\u590f\u81f3","\u5c0f\u6691","\u5927\u6691","\u7acb\u79cb","\u5904\u6691","\u767d\u9732","\u79cb\u5206","\u5bd2\u9732","\u971c\u964d","\u7acb\u51ac","\u5c0f\u96ea","\u5927\u96ea","\u51ac\u81f3"],
 
     /**
       * 1900-2100各年的24节气日期速查表
-      * @Array Of Property 
+      * @Array Of Property
       * @return 0x string For splice
       */
     sTermInfo:['9778397bd097c36b0b6fc9274c91aa','97b6b97bd19801ec9210c965cc920e','97bcf97c3598082c95f8c965cc920f',
@@ -153,25 +153,25 @@ var calendar = {
 
     /**
       * 数字转中文速查表
-      * @Array Of Property 
+      * @Array Of Property
       * @trans ['日','一','二','三','四','五','六','七','八','九','十']
-      * @return Cn string 
+      * @return Cn string
       */
     nStr1:["\u65e5","\u4e00","\u4e8c","\u4e09","\u56db","\u4e94","\u516d","\u4e03","\u516b","\u4e5d","\u5341"],
 
     /**
       * 日期转农历称呼速查表
-      * @Array Of Property 
+      * @Array Of Property
       * @trans ['初','十','廿','卅']
-      * @return Cn string 
+      * @return Cn string
       */
     nStr2:["\u521d","\u5341","\u5eff","\u5345"],
 
     /**
       * 月份转农历称呼速查表
-      * @Array Of Property 
+      * @Array Of Property
       * @trans ['正','一','二','三','四','五','六','七','八','九','十','冬','腊']
-      * @return Cn string 
+      * @return Cn string
       */
     nStr3:["\u6b63","\u4e8c","\u4e09","\u56db","\u4e94","\u516d","\u4e03","\u516b","\u4e5d","\u5341","\u51ac","\u814a"],
 
@@ -183,8 +183,8 @@ var calendar = {
       */
     lYearDays:function(y) {
         var i, sum = 348;
-        for(i=0x8000; i>0x8; i>>=1) { sum += (calendar.lunarInfo[y-1900] & i)? 1: 0; }
-        return(sum+calendar.leapDays(y));
+        for(i=0x8000; i>0x8; i>>=1) { sum += (this.lunarInfo[y-1900] & i)? 1: 0; }
+        return(sum+this.leapDays(y));
     },
 
     /**
@@ -194,7 +194,7 @@ var calendar = {
       * @eg:var leapMonth = calendar.leapMonth(1987) ;//leapMonth=6
       */
     leapMonth:function(y) { //闰字编码 \u95f0
-        return(calendar.lunarInfo[y-1900] & 0xf);
+        return(this.lunarInfo[y-1900] & 0xf);
     },
 
     /**
@@ -204,8 +204,8 @@ var calendar = {
       * @eg:var leapMonthDay = calendar.leapDays(1987) ;//leapMonthDay=29
       */
     leapDays:function(y) {
-        if(calendar.leapMonth(y))  { 
-            return((calendar.lunarInfo[y-1900] & 0x10000)? 30: 29); 
+        if(this.leapMonth(y))  {
+            return((this.lunarInfo[y-1900] & 0x10000)? 30: 29);
         }
         return(0);
     },
@@ -218,7 +218,7 @@ var calendar = {
       */
     monthDays:function(y,m) {
         if(m>12 || m<1) {return -1}//月份参数从1至12，参数错误返回-1
-        return( (calendar.lunarInfo[y-1900] & (0x10000>>m))? 30: 29 );
+        return( (this.lunarInfo[y-1900] & (0x10000>>m))? 30: 29 );
     },
 
     /**
@@ -233,7 +233,7 @@ var calendar = {
         if(ms==1) { //2月份的闰平规律测算后确认返回28或29
             return(((y%4 == 0) && (y%100 != 0) || (y%400 == 0))? 29: 28);
         }else {
-            return(calendar.solarMonth[ms]);
+            return(this.solarMonth[ms]);
         }
     },
 
@@ -247,8 +247,8 @@ var calendar = {
         var zhiKey = (lYear - 3) % 12;
         if(ganKey == 0) ganKey = 10;//如果余数为0则为最后一个天干
         if(zhiKey == 0) zhiKey = 12;//如果余数为0则为最后一个地支
-        return calendar.Gan[ganKey-1] + calendar.Zhi[zhiKey-1];
-        
+        return this.Gan[ganKey-1] + this.Zhi[zhiKey-1];
+
     },
 
     /**
@@ -269,19 +269,19 @@ var calendar = {
       * @return Cn string
       */
     toGanZhi:function(offset) {
-        return calendar.Gan[offset%10] + calendar.Zhi[offset%12];
+        return this.Gan[offset%10] + this.Zhi[offset%12];
     },
 
     /**
       * 传入公历(!)y年获得该年第n个节气的公历日期
-      * @param y公历年(1900-2100)；n二十四节气中的第几个节气(1~24)；从n=1(小寒)算起 
+      * @param y公历年(1900-2100)；n二十四节气中的第几个节气(1~24)；从n=1(小寒)算起
       * @return day Number
       * @eg:var _24 = calendar.getTerm(1987,3) ;//_24=4;意即1987年2月4日立春
       */
     getTerm:function(y,n) {
         if(y<1900 || y>2100) {return -1;}
         if(n<1 || n>24) {return -1;}
-        var _table = calendar.sTermInfo[y-1900];
+        var _table = this.sTermInfo[y-1900];
         var _info = [
             parseInt('0x'+_table.substr(0,5)).toString() ,
             parseInt('0x'+_table.substr(5,5)).toString(),
@@ -295,27 +295,27 @@ var calendar = {
             _info[0].substr(1,2),
             _info[0].substr(3,1),
             _info[0].substr(4,2),
-            
+
             _info[1].substr(0,1),
             _info[1].substr(1,2),
             _info[1].substr(3,1),
             _info[1].substr(4,2),
-            
+
             _info[2].substr(0,1),
             _info[2].substr(1,2),
             _info[2].substr(3,1),
             _info[2].substr(4,2),
-            
+
             _info[3].substr(0,1),
             _info[3].substr(1,2),
             _info[3].substr(3,1),
             _info[3].substr(4,2),
-            
+
             _info[4].substr(0,1),
             _info[4].substr(1,2),
             _info[4].substr(3,1),
             _info[4].substr(4,2),
-            
+
             _info[5].substr(0,1),
             _info[5].substr(1,2),
             _info[5].substr(3,1),
@@ -332,7 +332,7 @@ var calendar = {
       */
     toChinaMonth:function(m) { // 月 => \u6708
         if(m>12 || m<1) {return -1} //若参数错误 返回-1
-        var s = calendar.nStr3[m-1];
+        var s = this.nStr3[m-1];
         s+= "\u6708";//加上月字
         return s;
     },
@@ -355,8 +355,8 @@ var calendar = {
             s = '\u4e09\u5341'; break;
             break;
         default :
-            s = calendar.nStr2[Math.floor(d/10)];
-            s += calendar.nStr1[d%10];
+            s = this.nStr2[Math.floor(d/10)];
+            s += this.nStr1[d%10];
         }
         return(s);
     },
@@ -368,7 +368,7 @@ var calendar = {
       * @eg:var animal = calendar.getAnimal(1987) ;//animal='兔'
       */
     getAnimal: function(y) {
-        return calendar.Animals[(y - 4) % 12]
+        return this.Animals[(y - 4) % 12]
     },
 
     /**
@@ -401,13 +401,13 @@ var calendar = {
             d = objDate.getDate();
         var offset = (Date.UTC(objDate.getFullYear(),objDate.getMonth(),objDate.getDate()) - Date.UTC(1900,0,31))/86400000;
         for(i=1900; i<2101 && offset>0; i++) {
-            temp    = calendar.lYearDays(i);
+            temp    = this.lYearDays(i);
             offset -= temp;
         }
         if(offset<0) {
             offset+=temp; i--;
         }
-        
+
         //是否今天
         var isTodayObj = new Date(),
             isToday    = false;
@@ -416,25 +416,25 @@ var calendar = {
         }
         //星期几
         var nWeek = objDate.getDay(),
-           cWeek  = calendar.nStr1[nWeek];
+           cWeek  = this.nStr1[nWeek];
         //数字表示周几顺应天朝周一开始的惯例
         if(nWeek==0) {
             nWeek = 7;
         }
         //农历年
         var year   = i;
-        var leap   = calendar.leapMonth(i); //闰哪个月
+        var leap   = this.leapMonth(i); //闰哪个月
         var isLeap = false;
-        
+
         //效验闰月
         for(i=1; i<13 && offset>0; i++) {
             //闰月
-            if(leap>0 && i==(leap+1) && isLeap==false){ 
+            if(leap>0 && i==(leap+1) && isLeap==false){
                 --i;
-                isLeap = true; temp = calendar.leapDays(year); //计算农历闰月天数
+                isLeap = true; temp = this.leapDays(year); //计算农历闰月天数
             }
             else{
-                temp = calendar.monthDays(year, i);//计算农历普通月天数
+                temp = this.monthDays(year, i);//计算农历普通月天数
             }
             //解除闰月
             if(isLeap==true && i==(leap+1)) { isLeap = false; }
@@ -445,7 +445,7 @@ var calendar = {
         {
             if(isLeap){
                 isLeap = false;
-            }else{ 
+            }else{
                 isLeap = true; --i;
             }
         }
@@ -459,37 +459,37 @@ var calendar = {
         var day        = offset + 1;
         //天干地支处理
         var sm         = m-1;
-        var gzY        = calendar.toGanZhiYear(year);
-        
+        var gzY        = this.toGanZhiYear(year);
+
         // 当月的两个节气
         // bugfix-2017-7-24 11:03:38 use lunar Year Param `y` Not `year`
-        var firstNode  = calendar.getTerm(y,(m*2-1));//返回当月「节」为几日开始
-        var secondNode = calendar.getTerm(y,(m*2));//返回当月「节」为几日开始
+        var firstNode  = this.getTerm(y,(m*2-1));//返回当月「节」为几日开始
+        var secondNode = this.getTerm(y,(m*2));//返回当月「节」为几日开始
 
         // 依据12节气修正干支月
-        var gzM        = calendar.toGanZhi((y-1900)*12+m+11);
+        var gzM        = this.toGanZhi((y-1900)*12+m+11);
         if(d>=firstNode) {
-            gzM        = calendar.toGanZhi((y-1900)*12+m+12);
+            gzM        = this.toGanZhi((y-1900)*12+m+12);
         }
-        
+
         //传入的日期的节气与否
         var isTerm = false;
         var Term   = null;
         if(firstNode==d) {
             isTerm  = true;
-            Term    = calendar.solarTerm[m*2-2];
+            Term    = this.solarTerm[m*2-2];
         }
         if(secondNode==d) {
             isTerm  = true;
-            Term    = calendar.solarTerm[m*2-1];
+            Term    = this.solarTerm[m*2-1];
         }
         //日柱 当月一日与 1900/1/1 相差天数
         var dayCyclical = Date.UTC(y,sm,1,0,0,0,0)/86400000+25567+10;
-        var gzD         = calendar.toGanZhi(dayCyclical+d-1);
+        var gzD         = this.toGanZhi(dayCyclical+d-1);
         //该日期所属的星座
-        var astro       = calendar.toAstro(m,d);
-        
-        return {'lYear':year,'lMonth':month,'lDay':day,'Animal':calendar.getAnimal(year),'IMonthCn':(isLeap?"\u95f0":'')+calendar.toChinaMonth(month),'IDayCn':calendar.toChinaDay(day),'cYear':y,'cMonth':m,'cDay':d,'gzYear':gzY,'gzMonth':gzM,'gzDay':gzD,'isToday':isToday,'isLeap':isLeap,'nWeek':nWeek,'ncWeek':"\u661f\u671f"+cWeek,'isTerm':isTerm,'Term':Term,'astro':astro};
+        var astro       = this.toAstro(m,d);
+
+        return {'lYear':year,'lMonth':month,'lDay':day,'Animal':this.getAnimal(year),'IMonthCn':(isLeap?"\u95f0":'')+this.toChinaMonth(month),'IDayCn':this.toChinaDay(day),'cYear':y,'cMonth':m,'cDay':d,'gzYear':gzY,'gzMonth':gzM,'gzDay':gzD,'isToday':isToday,'isLeap':isLeap,'nWeek':nWeek,'ncWeek':"\u661f\u671f"+cWeek,'isTerm':isTerm,'Term':Term,'astro':astro};
     },
 
     /**
@@ -504,33 +504,33 @@ var calendar = {
     lunar2solar:function(y,m,d,isLeapMonth) {   //参数区间1900.1.31~2100.12.1
         var isLeapMonth = !!isLeapMonth;
         var leapOffset  = 0;
-        var leapMonth   = calendar.leapMonth(y);
-        var leapDay     = calendar.leapDays(y);
+        var leapMonth   = this.leapMonth(y);
+        var leapDay     = this.leapDays(y);
         if(isLeapMonth&&(leapMonth!=m)) {return -1;}//传参要求计算该闰月公历 但该年得出的闰月与传参的月份并不同
-        if(y==2100&&m==12&&d>1 || y==1900&&m==1&&d<31) {return -1;}//超出了最大极限值 
-        var day  = calendar.monthDays(y,m); 
+        if(y==2100&&m==12&&d>1 || y==1900&&m==1&&d<31) {return -1;}//超出了最大极限值
+        var day  = this.monthDays(y,m);
         var _day = day;
-        //bugFix 2016-9-25 
-        //if month is leap, _day use leapDays method 
+        //bugFix 2016-9-25
+        //if month is leap, _day use leapDays method
         if(isLeapMonth) {
-            _day = calendar.leapDays(y,m);
+            _day = this.leapDays(y,m);
         }
         if(y < 1900 || y > 2100 || d > _day) {return -1;}//参数合法性效验
-        
+
         //计算农历的时间差
         var offset = 0;
         for(var i=1900;i<y;i++) {
-            offset+=calendar.lYearDays(i);
+            offset+=this.lYearDays(i);
         }
         var leap = 0,isAdd= false;
         for(var i=1;i<m;i++) {
-            leap = calendar.leapMonth(y);
+            leap = this.leapMonth(y);
             if(!isAdd) {//处理闰月
                 if(leap<=i && leap>0) {
-                    offset+=calendar.leapDays(y);isAdd = true;
+                    offset+=this.leapDays(y);isAdd = true;
                 }
             }
-            offset+=calendar.monthDays(y,i);
+            offset+=this.monthDays(y,i);
         }
         //转换闰月农历 需补充该年闰月的前一个月的时差
         if(isLeapMonth) {offset+=day;}
@@ -541,6 +541,6 @@ var calendar = {
         var cM      =   calObj.getUTCMonth()+1;
         var cD      =   calObj.getUTCDate();
 
-        return calendar.solar2lunar(cY,cM,cD);
+        return this.solar2lunar(cY,cM,cD);
     }
 };


### PR DESCRIPTION
内部方法调用 和 属性访问使用 this 避免和外部变量同名

```javascript
<script src='./calendar.js'></script>
<script>
// 释放 calendar 变量名
window.chineseCalendar = window.calendar;
delete window.calendar;

(function() {
  var calendar = document.getElementById('calendar');
  // do something...
  // 如果没做修改的话，在移动端(iOS)这边会出错
  // calendar.js 里访问到的 calendar 是上面定义的变量，在 pc 端上的 chrome 66 倒是没事
  chineseCalendar.monthDays(year, month); 
})();
</script>
```