### PR TITLE
fix: 修复节气&农历日期显示错误的问题

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -362,38 +362,22 @@ export var calendar = {
             parseInt('0x'+_table.substr(20,5)).toString(),
             parseInt('0x'+_table.substr(25,5)).toString()
         ];
-        var _calday = [
-            _info[0].substr(0,1),
-            _info[0].substr(1,2),
-            _info[0].substr(3,1),
-            _info[0].substr(4,2),
-
-            _info[1].substr(0,1),
-            _info[1].substr(1,2),
-            _info[1].substr(3,1),
-            _info[1].substr(4,2),
-
-            _info[2].substr(0,1),
-            _info[2].substr(1,2),
-            _info[2].substr(3,1),
-            _info[2].substr(4,2),
-
-            _info[3].substr(0,1),
-            _info[3].substr(1,2),
-            _info[3].substr(3,1),
-            _info[3].substr(4,2),
-
-            _info[4].substr(0,1),
-            _info[4].substr(1,2),
-            _info[4].substr(3,1),
-            _info[4].substr(4,2),
-
-            _info[5].substr(0,1),
-            _info[5].substr(1,2),
-            _info[5].substr(3,1),
-            _info[5].substr(4,2),
-        ];
-        return parseInt(_calday[n-1]);
+        // bugfix-2021-12-06 使用map优化节气取值方式，根据month值获取当月的两个节气所在日期
+        let SolarTermsMap = {
+            0: [_info[0].substr(0, 1), _info[0].substr(1, 2)],
+            1: [_info[0].substr(3, 1), _info[0].substr(4, 2)],
+            2: [_info[1].substr(0, 1), _info[1].substr(1, 2)],
+            3: [_info[1].substr(3, 1), _info[1].substr(4, 2)],
+            4: [_info[2].substr(0, 1), _info[2].substr(1, 2)],
+            5: [_info[2].substr(3, 1), _info[2].substr(4, 2)],
+            6: [_info[3].substr(0, 1), _info[3].substr(1, 2)],
+            7: [_info[3].substr(3, 1), _info[3].substr(4, 2)],
+            8: [_info[4].substr(0, 1), _info[4].substr(1, 2)],
+            9: [_info[4].substr(3, 1), _info[4].substr(4, 2)],
+            10: [_info[5].substr(0, 1), _info[5].substr(1, 2)],
+            11: [_info[5].substr(3, 1), _info[5].substr(4, 2)]
+        };
+        return SolarTermsMap[n];
     },
 
     /**
@@ -451,10 +435,10 @@ export var calendar = {
       * @return JSON object
       * @eg:console.log(calendar.solar2lunar(1987,11,01));
       */
-    solar2lunar:function (y,m,d) { //参数区间1900.1.31~2100.12.31
-        y = parseInt(y)
-        m = parseInt(m)
-        d = parseInt(d)
+    solar2lunar:function (_y,_m,_d) { //参数区间1900.1.31~2100.12.31
+        y = parseInt(_y)
+        m = parseInt(_m)
+        d = parseInt(_d)
         //年份限定、上限
         if(y<1900 || y>2100) {
             return -1;// undefined转换为数字变为NaN
@@ -467,7 +451,8 @@ export var calendar = {
         if(!y) {
             var objDate = new Date();
         }else {
-            var objDate = new Date(y,parseInt(m)-1,d)
+            // bugfix-2021-12-06 正确获取日期
+            var objDate = new Date(y,parseInt(m),d)
         }
         var i, leap=0, temp=0;
         //修正ymd参数
@@ -538,8 +523,13 @@ export var calendar = {
 
         // 当月的两个节气
         // bugfix-2017-7-24 11:03:38 use lunar Year Param `y` Not `year`
-        var firstNode  = this.getTerm(y,(m*2-1));//返回当月「节」为几日开始
-        var secondNode = this.getTerm(y,(m*2));//返回当月「节」为几日开始
+        // var firstNode  = this.getTerm(y,(m*2-1));//返回当月「节」为几日开始
+        // var secondNode = this.getTerm(y,(m*2));//返回当月「节」为几日开始
+
+        // bugfix-2021-12-06 使用map优化节气取值方式，正确获取节气
+        let termNodeList = this.getTerm(_y, _m);
+        var firstNode  = termNodeList[0]//返回当月「节」为几日开始
+        var secondNode = termNodeList[1]//返回当月「节」为几日开始
 
         // 依据12节气修正干支月
         var gzM        = this.toGanZhi((y-1900)*12+m+11);


### PR DESCRIPTION
初次使用这个插件，没有作任何修改，发现有以下两个问题：![image](https://user-images.githubusercontent.com/49339389/144834267-34cf7a37-6513-4357-b4d2-bc317c2effa8.png)1、每月最后一天和下个月的第一天，比如31号跟1号，显示出的农历信息重复
2、获取到的节气是错误的
如图：

我以为是我传参问题，但是不论我怎么修改，都无法正确的显示相应信息。后查看源码，发现部分逻辑存在错误之处，已经在pr中做修改。

以上修改都经过验证，已经能拿到正确信息。第一次提pr，不太懂操作，如果pr代码中或者提交操作上有不妥之处，望指出，我会及时更改。