### PR TITLE
fix: fix capricorn character errors

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -338,7 +338,7 @@ export const calendar = {
      * @return Cn string
      */
     toAstro: function (cMonth, cDay) {
-        const s = "\u9b54\u7faf\u6c34\u74f6\u53cc\u9c7c\u767d\u7f8a\u91d1\u725b\u53cc\u5b50\u5de8\u87f9\u72ee\u5b50\u5904\u5973\u5929\u79e4\u5929\u874e\u5c04\u624b\u9b54\u7faf";
+        const s = "\u6469\u7faf\u6c34\u74f6\u53cc\u9c7c\u767d\u7f8a\u91d1\u725b\u53cc\u5b50\u5de8\u87f9\u72ee\u5b50\u5904\u5973\u5929\u79e4\u5929\u874e\u5c04\u624b\u6469\u7faf";
         const arr = [20, 19, 21, 21, 21, 22, 23, 23, 23, 23, 22, 22];
         return s.substr(cMonth * 2 - (cDay < arr[cMonth - 1] ? 2 : 0), 2) + "\u5ea7";//座
     },


### PR DESCRIPTION

嗨～

修复摩羯星座文案错误，当前为**魔羯**，应该为**摩羯**。

-----------------

Hi~

Fix the copywriting error of the Capricorn constellation. It is currently Capricorn and should be Capricorn.
